### PR TITLE
fix: correct run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pip install -r requirements.txt
 
 ### 4️⃣ Run the Application
 ```bash
-python app.py
+python main.py
 ```
 
 ---


### PR DESCRIPTION
### What
Corrected the run command in README.

### Why
README instructed running `python app.py`, but the entry file is `main.py`.

### How
Updated the run command to reflect the actual file name.

### Testing
Verified file structure and confirmed `app.py` does not exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and run instructions to reflect the correct application entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->